### PR TITLE
fix header for CDN distro

### DIFF
--- a/midnight.jquery.js
+++ b/midnight.jquery.js
@@ -1,7 +1,7 @@
 /**
- * midnight.js
- * Switches dynamically between multiple header designs, so it looks in line with the content below it.
- * Crafted at Aerolab
+ * midnight.js v1.0.0
+ * jQuery plugin to switch dynamically between multiple header designs, so it looks in line with the content below it.
+ * (c)2014 Aerolab, @license WTFPL
  */
 
 


### PR DESCRIPTION
I'd like to host this on the [jsDelivr  CDN](http://www.jsdelivr.com/), but needs a version & license since we host only OSS.  (Feel free to fill in your own files.)
Noted the jQuery dependency. (also helps with searches)
v1.0.0 would be more accurate according to [SemVer](http://semver.org/).  You're public, & it works great.  If you make API changes later, then that would be v2.0.0.
