### PR TITLE
Shorten setInterval call

### DIFF
--- a/midnight.jquery.js
+++ b/midnight.jquery.js
@@ -248,9 +248,7 @@
 
       // NANANANANANANANA GRASAAAAA
       // (This is the ghetto way of keeping the section values updated after any kind of reflow. The overhead is minimal)
-      setInterval(function(){
-        recalculateSections();
-      }, 1000);
+      setInterval(recalculateSections, 1000);
 
 
       var recalculateHeaders = function(){


### PR DESCRIPTION
The interval step callback and just be the single function which gets called inside current callback.
