### PR TITLE
fix version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+*.log
+node_modules
+build
+*.node
+components
+coverage
+*.orig
+.idea

--- a/Copyright
+++ b/Copyright
@@ -2,9 +2,9 @@
  * Midnight.js <%= version %>
  * jQuery plugin to switch between multiple fixed header designs on the fly, so it looks in line with the content below it.
  * http://aerolab.github.io/midnight.js/
- * 
+ *
  * Copyright (c) 2014 Aerolab <info@aerolab.co>
- * 
+ *
  * Released under the MIT license
  * http://aerolab.github.io/midnight.js/LICENSE.txt
  */

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,13 @@ var getCopyright = function () {
     return fs.readFileSync('Copyright');
 };
 
+gulp.task('buildfromsrc', function () {
+    gulp.src('./midnight.jquery.src.js')
+    .pipe(header(getCopyright(), {version: getVersion()}))
+    .pipe(concat('midnight.jquery.js'))
+    .pipe(gulp.dest(''));
+});
+
 // task
 gulp.task('minifyjs', function () {
     gulp.src('./midnight.jquery.js')
@@ -21,4 +28,4 @@ gulp.task('minifyjs', function () {
     .pipe(gulp.dest(''));
 });
 
-gulp.task('default', ['minifyjs']);
+gulp.task('default', ['buildfromsrc', 'minifyjs']);

--- a/midnight.jquery.min.js
+++ b/midnight.jquery.min.js
@@ -1,10 +1,10 @@
 /*!
- * Midnight.js 1.0.0
+ * Midnight.js 1.0.2
  * jQuery plugin to switch between multiple fixed header designs on the fly, so it looks in line with the content below it.
  * http://aerolab.github.io/midnight.js/
- * 
+ *
  * Copyright (c) 2014 Aerolab <info@aerolab.co>
- * 
+ *
  * Released under the MIT license
  * http://aerolab.github.io/midnight.js/LICENSE.txt
  */

--- a/midnight.jquery.src.js
+++ b/midnight.jquery.src.js
@@ -1,14 +1,4 @@
-/*!
- * Midnight.js 1.0.2
- * jQuery plugin to switch between multiple fixed header designs on the fly, so it looks in line with the content below it.
- * http://aerolab.github.io/midnight.js/
- *
- * Copyright (c) 2014 Aerolab <info@aerolab.co>
- *
- * Released under the MIT license
- * http://aerolab.github.io/midnight.js/LICENSE.txt
- */
- ((function ( $ ) {
+((function ( $ ) {
 
   $.fn.midnight = function( customOptions ) {
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Midnight.JS",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "A jQuery plugin to switch fixed headers on the fly",
   "devDependencies": {
     "gulp": "^3.8.8",


### PR DESCRIPTION
Split `src.js` off of `midnight.jquery.js`
Add Gulp task to add fresh header to src, output to `midnight.jquery.js` (So please edit `midnight.jquery.src.js` from now on)
Add `.gitignore`
actually changed version in `package.json` to match [release 1.0.2](https://github.com/Aerolab/midnight.js/releases/tag/1.0.2) :)
ref #11 to prepare for CDN
