### PR TITLE
Simplify root closure

### DIFF
--- a/midnight.jquery.js
+++ b/midnight.jquery.js
@@ -8,7 +8,7 @@
  * Released under the MIT license
  * http://aerolab.github.io/midnight.js/LICENSE.txt
  */
- ((function ( $ ) {
+ (function( $ ) {
 
   $.fn.midnight = function( customOptions ) {
 
@@ -413,4 +413,4 @@
 
   };
 
-})(jQuery));
+}(jQuery));


### PR DESCRIPTION
The extra pair of parens around the self-executing function's declaration can be removed.
